### PR TITLE
Restored MAC to IP tab

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.10 (network-architecture-verification-and-validation)" />
+  </component>
   <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (network-architecture-verification-and-validation)" project-jdk-type="Python SDK" />
 </project>

--- a/src/navv/commands.py
+++ b/src/navv/commands.py
@@ -8,7 +8,7 @@ import click
 
 # cisagov Libraries
 from navv.gui.app import app
-from navv.bll import get_inventory_report_df, get_snmp_df, get_zeek_df
+from navv.bll import get_inventory_report_df, get_snmp_df, get_zeek_df, get_mac_df
 from navv.message_handler import success_msg, warning_msg
 from navv.spreadsheet_tools import (
     auto_adjust_width,
@@ -24,6 +24,7 @@ from navv.spreadsheet_tools import (
     write_snmp_sheet,
     write_stats_sheet,
     write_unknown_internals_sheet,
+    write_mac_sheet,
 )
 from navv.zeek import (
     get_conn_data,
@@ -90,6 +91,7 @@ def generate(customer_name, output_dir, pcap, zeek_logs):
 
     # Get inventory report dataframe
     inventory_df = get_inventory_report_df(zeek_df)
+    mac_df = get_mac_df(zeek_df)
 
     # Turn zeekcut data into rows for spreadsheet
     rows = create_analysis_array(zeek_data, timer=timer_data)
@@ -117,6 +119,8 @@ def generate(customer_name, output_dir, pcap, zeek_logs):
     write_unknown_internals_sheet(unk_int_IPs, wb)
 
     write_snmp_sheet(snmp_df, wb)
+
+    write_mac_sheet(mac_df, wb)
 
     auto_adjust_width(wb["Analysis"])
 

--- a/src/navv/spreadsheet_tools.py
+++ b/src/navv/spreadsheet_tools.py
@@ -14,6 +14,7 @@ import string
 
 import openpyxl
 import openpyxl.styles
+from openpyxl.styles import Alignment
 from openpyxl.worksheet.table import Table
 import netaddr
 from tqdm import tqdm
@@ -470,6 +471,31 @@ def write_stats_sheet(wb, stats):
         stats_sheet[f"{string.ascii_uppercase[col_index]}2"].value = stats[stat]
     auto_adjust_width(stats_sheet)
 
+def write_mac_sheet(mac_df, wb):
+    """Fill spreadsheet with MAC address -> IP address translation with manufacturer information"""
+    sheet = make_sheet(wb, "MAC", idx=4)
+    sheet.append(
+        ["MAC", "Manufacturer", "IPs"]
+    )
+    for index, row in enumerate(mac_df.to_dict(orient="records"), start=2):
+        # Source MAC column
+        sheet[f"A{index}"].value = row["mac"]
+
+        # Source Manufacturer column
+        sheet[f"B{index}"].value = row["vendor"]
+
+        # Source IPs
+        sheet[f"C{index}"].value = row["associated_ip"]
+        if len(row["associated_ip"]) > 16:
+            sel_cell = sheet[f"C{index}"]
+            sel_cell.alignment = Alignment(wrap_text=True)
+            est_row_hght = int(len(row["associated_ip"])/50)
+            if est_row_hght < 1:
+                est_row_hght = 1
+            sheet.row_dimensions[index].height = est_row_hght * 15
+
+    auto_adjust_width(sheet)
+    sheet.column_dimensions["C"].width = 39 * 1.2
 
 def make_sheet(wb, sheet_name, idx=None):
     """Create the sheet if it doesn't already exist otherwise remove it and recreate it"""


### PR DESCRIPTION
With Inventory Report Tab not providing clear information (Source and Destination MAC Addresses and IPs are merged in rows), the restoration of this tab provides clear visibility to identify devices based upon MAC address and the observed IP addresses seen with that MAC Address.

## 🗣 HOT FIX to Restore MAC Tab Functionality ##
* Added MAC Tab to show all observed MAC Addresses with identified Vendor information based upon the MAC prefix. IP addresses observed during capture are shown in column with associated MAC Address.
* MAC Vendors are based off of downloaded Vendor Table.