### PR TITLE
update docker-related scripts to get them working and other minor miscellaneous fixes

### DIFF
--- a/.github/workflows/navv-build-push-ghcr.yml
+++ b/.github/workflows/navv-build-push-ghcr.yml
@@ -17,30 +17,30 @@ jobs:
     steps:
       -
         name: Cancel previous run in progress
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           ignore_sha: true
           all_but_latest: true
           access_token: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       -
         name: Log in to registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./docker/Dockerfile

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,9 +10,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4.7.0
         with:
           python-version: "3.10"
       - name: Install pypa/build

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ help:
 
 # target: install-develop - Install application for development
 install-develop:
-	pip install -e .
+	python3 -m pip install -e .
 
 # target: install - Install production application
 install:
-	pip install navv
+	python3 -m pip install navv
 
 # target: generate - Generate analysis excel sheet
 # optionally set PCAP_PATH to a relative pcap file path

--- a/README.md
+++ b/README.md
@@ -137,15 +137,6 @@ Developers, by contributing to this software project, you are agreeing to the fo
 * You agree your contributions are submitted under the BSD 3-Clause license.
 * You represent you are authorized to make the contributions and grant the license. If your employer has rights to intellectual property that includes your contributions, you represent that you have received permission to make contributions and grant the required license on behalf of that employer.
 
-## Other software ##
-
-Idaho National Laboratory is a cutting edge research facility which is constantly producing high quality research and software. Feel free to take a look at our other software and scientific offerings at:
-
-* [Primary Technology Offerings Page](https://www.inl.gov/inl-initiatives/technology-deployment)
-* [Supported Open Source Software](https://github.com/cisagov)
-* [Raw Experiment Open Source Software](https://github.com/IdahoLabResearch)
-* [Unsupported Open Source Software](https://github.com/IdahoLabCuttingBoard)
-
 ## Contact ##
 
 Contact information of maintainer(s):

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you intend to develop the NAVV tool:
 - Activate your local environment
   - `source .venv/bin/activate`
 - Install the project and its dependencies to your local virtual environment
-  - `pip install -e .`
+  - `python3 -m pip install -e .`
 
 ### Production ###
 
@@ -48,9 +48,9 @@ If you would like to use the NAVV tool, its recommended you install it from PYPI
 - Install the project using `pip`
   - The recommended method for installing packages with `pip` is using [User Installs](https://pip.pypa.io/en/stable/user_guide/#user-installs) which installs to a user-specific location rather than system-wide.
   - install the latest version of NAVV
-    - `pip install -U navv`
+    - `python3 -m pip install -U navv`
   - or install a specific version of NAVV
-    - example:  `pip install -U navv==3.0.1`
+    - example:  `python3 -m pip install -U navv==3.0.1`
 
 Verify the NAVV tool has been installed by running `navv` in your console:
 
@@ -128,7 +128,7 @@ See [`docker/README.md`](./docker/README.md) for setup and instructions for runn
 
 ## Copyright ##
 
-[NAVV](https://github.com/cisagov/network-architecture-verification-and-validation) is Copyright 2023 Battelle Energy Alliance, LLC, licensed under the BSD-3 Clause License.
+[NAVV](https://github.com/cisagov/network-architecture-verification-and-validation) is Copyright 2024 Battelle Energy Alliance, LLC, licensed under the BSD-3 Clause License.
 
 See [`LICENSE`](./LICENSE) for the terms of its release.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:kinetic
+FROM ubuntu:jammy
 
-# Copyright 2023 Battelle Energy Alliance, LLC
+# Copyright 2024 Battelle Energy Alliance, LLC
 
 LABEL maintainer="seth.grover@inl.gov"
 LABEL org.opencontainers.image.authors='seth.grover@inl.gov'
@@ -68,6 +68,8 @@ RUN groupadd --gid ${DEFAULT_GID} ${PUSER} && \
     mkdir -p /home/${PUSER} /dist && \
     chown ${DEFAULT_UID}:${DEFAULT_GID} /home/${PUSER} /dist && \
     chmod 755 /home/${PUSER} /dist
+
+EXPOSE 5000
 
 # entrypoint to drop privileges to non-privileged user and run navv
 ENTRYPOINT [ "/usr/local/bin/docker-uid-gid-setup.sh", "/usr/bin/python3", "-m", "navv" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -104,6 +104,6 @@ total 9.4M
 ```
 ## <a name="Footer"></a>Copyright
 
-[NAVV](https://github.com/cisagov/network-architecture-verification-and-validation) is Copyright 2023 Battelle Energy Alliance, LLC, licensed under the BSD-3 Clause License.
+[NAVV](https://github.com/cisagov/network-architecture-verification-and-validation) is Copyright 2024 Battelle Energy Alliance, LLC, licensed under the BSD-3 Clause License.
 
 See [`LICENSE`](./LICENSE) for the terms of its release.

--- a/docker/backup_docker.sh
+++ b/docker/backup_docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2023 Battelle Energy Alliance, LLC
+# Copyright 2024 Battelle Energy Alliance, LLC
 
 set -e
 set -o pipefail

--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2023 Battelle Energy Alliance, LLC
+# Copyright 2024 Battelle Energy Alliance, LLC
 
 set -e
 set -o pipefail

--- a/docker/local.zeek
+++ b/docker/local.zeek
@@ -11,7 +11,6 @@ redef ignore_checksums = T;
 # redef SOCKS::default_capture_password = T;
 
 @load tuning/defaults
-@load misc/scan
 @load frameworks/software/vulnerable
 @load frameworks/software/version-changes
 @load frameworks/software/windows-version-detection

--- a/docker/navv-build-for-export.sh
+++ b/docker/navv-build-for-export.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2023 Battelle Energy Alliance, LLC
+# Copyright 2024 Battelle Energy Alliance, LLC
 
 set -o pipefail
 set -u

--- a/docker/navv-docker.sh
+++ b/docker/navv-docker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2023 Battelle Energy Alliance, LLC
+# Copyright 2024 Battelle Energy Alliance, LLC
 
 # navv_docker.sh
 #
@@ -186,6 +186,7 @@ $CONTAINER_ENGINE run --rm \
   -w /output \
   "${MOUNT_ARGS[@]}" \
   "$NAVV_DOCKER_IMAGE" \
+  generate \
   "${IN_ARGS[@]}" \
   "${OUT_ARGS[@]}" \
   "$CUSTOMER_NAME"

--- a/setup-env
+++ b/setup-env
@@ -149,7 +149,7 @@ python3 -m pip install --upgrade pip setuptools wheel
 # Find a requirements file (if possible) and install
 for req_file in "requirements-dev.txt" "requirements-test.txt" "requirements.txt"; do
   if [[ -f $req_file ]]; then
-    pip install --requirement $req_file
+    python3 -m pip install --requirement $req_file
     break
   fi
 done

--- a/src/navv/commands.py
+++ b/src/navv/commands.py
@@ -43,6 +43,7 @@ from navv.utilities import pushd
     required=False,
     help="Directory to place resultant analysis files in. Defaults to current working directory.",
     type=str,
+    default=os.getcwd(),
 )
 @click.option(
     "-p",
@@ -57,6 +58,7 @@ from navv.utilities import pushd
     required=False,
     help="Path to store or contain zeek log files. Defaults to current working directory.",
     type=str,
+    default=os.getcwd(),
 )
 @click.argument("customer_name")
 def generate(customer_name, output_dir, pcap, zeek_logs):

--- a/src/navv/data_types.py
+++ b/src/navv/data_types.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2023 Battelle Energy Alliance, LLC
+# Copyright 2024 Battelle Energy Alliance, LLC
 
 from dataclasses import dataclass, field
 import netaddr

--- a/src/navv/network_analysis.py
+++ b/src/navv/network_analysis.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2023 Battelle Energy Alliance, LLC
+# Copyright 2024 Battelle Energy Alliance, LLC
 
 # python std library imports
 import pkg_resources

--- a/src/navv/spreadsheet_tools.py
+++ b/src/navv/spreadsheet_tools.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2023 Battelle Energy Alliance, LLC
+# Copyright 2024 Battelle Energy Alliance, LLC
 
 import os
 import itertools

--- a/src/navv/utilities.py
+++ b/src/navv/utilities.py
@@ -15,7 +15,9 @@ from navv.validators import is_mac_address
 @contextlib.contextmanager
 def pushd(new_dir):
     previous_dir = os.getcwd()
-    if not os.path.isdir(new_dir):
+    if not new_dir:
+        new_dir = previous_dir
+    elif not os.path.isdir(new_dir):
         os.makedirs(new_dir)
     os.chdir(new_dir)
     try:


### PR DESCRIPTION
Updates to get Dockerized version working correctly and other miscellany

* updated github workflow actions' versions
* standardized in scripting and documentation calls to pip (from "pip" to "python3 -m pip")
* updated copyright year to 2024
* update base Docker image from Ubuntu kinetic to jammy
* added "EXPOSE 5000" directive to Dockerfile for web UI server (although did not test the web UI server through docker)
* removed deprecated misc/scan script (which is no longer maintained and will be removed) from local.zeek
* updated navv-docker.sh command to run `generate` as default command
* handled case in pushd context manager where new_dir was being passed in as None, causing an exception
* although the documentation specified --output-dir and --zeek-logs would default to the current directory, this was not being done; added default=os.getcwd() to @click.option for those two parameters

@Dbones202  I've only tested the CLI `generate` command from within the docker container and via the `navv-docker.sh` script, and did not test/run/mess with anything to do with the web UI. While I don't think any of my changes should have any effect on the UI command, you might want to double-check that.