### PR TITLE
Bump version to 4.0.1 and package *.toml data files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
 where = src
 
 [options.package_data]
-navv = data/*.pkl, data/*.json, gui/templates/*.html, gui/static/*.js, gui/static/*.css, gui/static/css/*.css, gui/static/css/*.css.map, gui/static/img/*.png, gui/static/js/*.js, gui/static/js/*.js.map
+navv = data/*.toml, data/*.json, gui/templates/*.html, gui/static/*.js, gui/static/*.css, gui/static/css/*.css, gui/static/css/*.css.map, gui/static/img/*.png, gui/static/js/*.js, gui/static/js/*.js.map
 
 [options.entry_points]
 console_scripts =

--- a/src/navv/_version.py
+++ b/src/navv/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "4.0.0"
+__version__ = "4.0.1"


### PR DESCRIPTION
This PR bumps the package version to 4.0.1 in `src/navv/_version.py` and updates `setup.cfg` to include and package `*.toml` data files instead of `*.pkl` files, aligning with the recent transition from pickle to TOML data structures.